### PR TITLE
Allow passing of SSL configuration block to the Nomad client

### DIFF
--- a/lib/nomad_client/configuration.rb
+++ b/lib/nomad_client/configuration.rb
@@ -9,12 +9,18 @@ module NomadClient
     # Nomad's HTTP API base path, as of writing this is /v1
     attr_accessor :api_base_path
 
+    # SSL configuration hash, specifically the one Faraday expects,
+    # see https://gist.github.com/mislav/938183 for a quick example
+    attr_accessor :ssl
+
     DEFAULT_PORT          = 4646.freeze
     DEFAULT_API_BASE_PATH = '/v1'.freeze
+    DEFAULT_SSL           = {}.freeze
 
     def initialize
       @port          = DEFAULT_PORT
       @api_base_path = DEFAULT_API_BASE_PATH
+      @ssl           = DEFAULT_SSL
     end
   end
 end

--- a/lib/nomad_client/connection.rb
+++ b/lib/nomad_client/connection.rb
@@ -12,12 +12,16 @@ module NomadClient
     end
 
     def connection
-      ::Faraday.new(url: "#{configuration.url}:#{configuration.port}#{configuration.api_base_path}") do |faraday|
+      ::Faraday.new({ url: connection_url, ssl: configuration.ssl }) do |faraday|
         faraday.request(:json)
         faraday.use(FaradayMiddleware::Mashify)
         faraday.response(:json, :content_type => /\bjson$/)
         faraday.adapter(Faraday.default_adapter)
       end
+    end
+
+    def connection_url
+      "#{configuration.url}:#{configuration.port}#{configuration.api_base_path}"
     end
   end
 end

--- a/lib/nomad_client/version.rb
+++ b/lib/nomad_client/version.rb
@@ -1,3 +1,3 @@
 module NomadClient
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/nomad_client/connection_spec.rb
+++ b/spec/nomad_client/connection_spec.rb
@@ -10,20 +10,25 @@ module NomadClient
           expect(nomad_client.configuration.url).to           eq nomad_url
           expect(nomad_client.configuration.port).to          eq Configuration::DEFAULT_PORT
           expect(nomad_client.configuration.api_base_path).to eq Configuration::DEFAULT_API_BASE_PATH
+          expect(nomad_client.configuration.ssl).to           be_empty
         end
       end
       context 'with a configuration block passed' do
         it 'should override default configration' do
-          port = 4647
+          port          = 4647
           api_base_path = '/v2'
+          ssl_config    = { client_cert: '/tmp/my.crt',  client_key: '/tmp/my.key' }
           nomad_client = NomadClient::Connection.new(nomad_url) do |config|
             config.port          = port
             config.api_base_path = api_base_path
+            config.ssl           = ssl_config
           end
 
           expect(nomad_client.configuration.url).to           eq nomad_url
           expect(nomad_client.configuration.port).to          eq port
           expect(nomad_client.configuration.api_base_path).to eq api_base_path
+          expect(nomad_client.configuration.ssl).to           eq ssl_config
+          expect(nomad_client.connection.ssl).to_not          be_empty
         end
       end
     end


### PR DESCRIPTION
For those who need SSL configuration in their Nomad connections.