### PR TITLE
Add deployments support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Changelog for nomad_client.
+
+## 0.2.0
+
+* Adds the classes and attributes required for dealing with the deployment endpoints
+
+## 0.1.1
+
+* Allows using SSL with the Nomad client
+
+## 0.1.0
+
+* First commit. Adds most endpoints supported at the time of writing the gem.

--- a/lib/nomad_client/api.rb
+++ b/lib/nomad_client/api.rb
@@ -5,6 +5,8 @@ module NomadClient
     require_relative 'api/allocation'
     require_relative 'api/allocations'
     require_relative 'api/client'
+    require_relative 'api/deployment'
+    require_relative 'api/deployments'
     require_relative 'api/evaluation'
     require_relative 'api/evaluations'
     require_relative 'api/job'

--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -45,18 +45,31 @@ module NomadClient
       end
 
       ##
-      # Pause or unpause a deployment. This is done to pause a rolling upgrade or resume it.
+      # Pause a deployment. This is done to pause a rolling upgrade.
       # https://www.nomadproject.io/api/deployments.html
       #
       # @param [String] id The ID of the deployment according to Nomad
-      # @param [Boolean] pause True if pausing, false if unpausing
       # @return [Faraday::Response] A faraday response from Nomad
-      def pause(id, pause)
+      def pause(id)
         connection.post do |req|
           req.url "deployment/pause/#{id}"
-          req.params[:Pause] = pause
+          req.params[:Pause] = true
         end
       end
+
+      ##
+      # Resume a deployment. This is done to resume a rolling upgrade.
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def unpause(id)
+        connection.post do |req|
+          req.url "deployment/pause/#{id}"
+          req.params[:Pause] = false
+        end
+      end
+      alias_method :resume, :unpause
 
       ##
       # Promote task groups that have canaries for a deployment. This should be done when the placed canaries are healthy and the rolling upgrade of the remaining allocations should begin.

--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -81,13 +81,14 @@ module NomadClient
       # https://www.nomadproject.io/api/deployments.html
       #
       # @param [String] id The ID of the deployment according to Nomad
-      # @param [Hash[Array]] allocation_ids A hash of arrays, keyed with `healthy_allocation_ids` and `unhealthy_allocation_ids`, both of which should be arrays (or nil)
+      # @param [Array[String]] healthy_allocation_ids Specifies the set of allocation that should be marked as healthy
+      # @param [Array[String]] unhealthy_allocation_ids Specifies the set of allocation that should be marked as unhealthy
       # @return [Faraday::Response] A faraday response from Nomad
-      def allocation_health(id, allocation_ids = { healthy_allocation_ids: nil, unhealthy_allocation_ids: nil })
+      def allocation_health(id, healthy_allocation_ids: nil, unhealthy_allocation_ids: nil)
         connection.post do |req|
           req.url "deployment/allocation-health/#{id}"
-          req.params[:HealthyAllocationIDs]   = allocation_ids[:healthy_allocation_ids]
-          req.params[:UnhealthyAllocationIDs] = allocation_ids[:unhealthy_allocation_ids]
+          req.params[:HealthyAllocationIDs]   = healthy_allocation_ids
+          req.params[:UnhealthyAllocationIDs] = unhealthy_allocation_ids
         end
       end
     end

--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -1,0 +1,95 @@
+module NomadClient
+  class Connection
+    def deployment
+      Api::Deployment.new(self)
+    end
+  end
+  module Api
+    class Deployment < Path
+
+      ##
+      # Query a specific deployment
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def get(id)
+        connection.get do |req|
+          req.url "deployment/#{id}"
+        end
+      end
+
+      ##
+      # Query the allocations created or modified for the given deployment
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def allocations(id)
+        connection.get do |req|
+          req.url "deployment/allocations/#{id}"
+        end
+      end
+
+      ##
+      # Mark a deployment as failed.
+      # This should be done to force the scheduler to stop creating allocations as part of the deployment or to cause a rollback to a previous job version.
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def fail(id)
+        connection.post do |req|
+          req.url "deployment/fail/#{id}"
+        end
+      end
+
+      ##
+      # Pause or unpause a deployment. This is done to pause a rolling upgrade or resume it.
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @param [Boolean] pause True if pausing, false if unpausing
+      # @return [Faraday::Response] A faraday response from Nomad
+      def pause(id, pause)
+        connection.post do |req|
+          req.url "deployment/pause/#{id}"
+          req.params[:Pause] = pause
+        end
+      end
+
+      ##
+      # Promote task groups that have canaries for a deployment. This should be done when the placed canaries are healthy and the rolling upgrade of the remaining allocations should begin.
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @param [Boolean] all Whether all task groups should be promoted
+      # @param [Array[String]] groups A particular set of task groups that should be promoted
+      # @return [Faraday::Response] A faraday response from Nomad
+      def promote(id, all = false, groups = nil)
+        connection.post do |req|
+          req.url "deployment/promote/#{id}"
+          req.params[:All] = all
+          req.params[:Groups] = groups
+        end
+      end
+
+      ##
+      # Set the health of an allocation that is in the deployment manually. In some use cases, automatic detection of allocation health may not be desired.
+      # As such those task groups can be marked with an upgrade policy that uses health_check = "manual". Those allocations must have their health marked manually using this endpoint.
+      # Marking an allocation as healthy will allow the rolling upgrade to proceed. Marking it as failed will cause the deployment to fail.
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @param [String] id The ID of the deployment according to Nomad
+      # @param [Hash[Array]] allocation_ids A hash of arrays, keyed with `healthy_allocation_ids` and `unhealthy_allocation_ids`, both of which should be arrays (or nil)
+      # @return [Faraday::Response] A faraday response from Nomad
+      def allocation_health(id, allocation_ids = { healthy_allocation_ids: nil, unhealthy_allocation_ids: nil })
+        connection.post do |req|
+          req.url "deployment/allocation-health/#{id}"
+          req.params[:HealthyAllocationIDs]   = allocation_ids[:healthy_allocation_ids]
+          req.params[:UnhealthyAllocationIDs] = allocation_ids[:unhealthy_allocation_ids]
+        end
+      end
+    end
+  end
+end

--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -66,7 +66,7 @@ module NomadClient
       # @param [Boolean] all Whether all task groups should be promoted
       # @param [Array[String]] groups A particular set of task groups that should be promoted
       # @return [Faraday::Response] A faraday response from Nomad
-      def promote(id, all = false, groups = nil)
+      def promote(id, all: false, groups: nil)
         connection.post do |req|
           req.url "deployment/promote/#{id}"
           req.params[:All] = all

--- a/lib/nomad_client/api/deployments.rb
+++ b/lib/nomad_client/api/deployments.rb
@@ -1,0 +1,22 @@
+module NomadClient
+  class Connection
+    def deployments
+      Api::Deployments.new(self)
+    end
+  end
+  module Api
+    class Deployments < Path
+
+      ##
+      # Lists all the deployments
+      # https://www.nomadproject.io/api/deployments.html
+      #
+      # @return [Faraday::Response] A faraday response from Nomad
+      def get
+        connection.get do |req|
+          req.url "deployments"
+        end
+      end
+    end
+  end
+end

--- a/lib/nomad_client/api/deployments.rb
+++ b/lib/nomad_client/api/deployments.rb
@@ -11,10 +11,13 @@ module NomadClient
       # Lists all the deployments
       # https://www.nomadproject.io/api/deployments.html
       #
+      # @param [String] prefix Specifies a string to filter deployments on based on an index prefix. This is specified as a querystring parameter.
+      #
       # @return [Faraday::Response] A faraday response from Nomad
-      def get
+      def get(prefix = nil)
         connection.get do |req|
           req.url "deployments"
+          req.params[:prefix] = prefix
         end
       end
     end

--- a/lib/nomad_client/api/deployments.rb
+++ b/lib/nomad_client/api/deployments.rb
@@ -14,7 +14,7 @@ module NomadClient
       # @param [String] prefix Specifies a string to filter deployments on based on an index prefix. This is specified as a querystring parameter.
       #
       # @return [Faraday::Response] A faraday response from Nomad
-      def get(prefix = nil)
+      def get(prefix: nil)
         connection.get do |req|
           req.url "deployments"
           req.params[:prefix] = prefix

--- a/lib/nomad_client/api/node.rb
+++ b/lib/nomad_client/api/node.rb
@@ -39,7 +39,7 @@ module NomadClient
       # @param [String] id ID of the node to drain
       # @param [Boolean] enable Boolean value provided as a query parameter to either set enabled to true or false
       # @return [Faraday::Response] A faraday response from Nomad
-      def drain(id, enable = true)
+      def drain(id, enable: true)
         connection.post do |req|
           req.url "node/#{id}/drain"
           req.params[:enable] = enable

--- a/lib/nomad_client/version.rb
+++ b/lib/nomad_client/version.rb
@@ -1,3 +1,3 @@
 module NomadClient
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -84,7 +84,7 @@ module NomadClient
               expect(promote_params).to receive(:[]=).with(:All, true)
               expect(promote_params).to receive(:[]=).with(:Groups, nil)
 
-              nomad_client.deployment.promote(deployment_id, true)
+              nomad_client.deployment.promote(deployment_id, all: true)
             end
           end
           context 'when promoting a subset' do
@@ -97,7 +97,7 @@ module NomadClient
               expect(promote_params).to receive(:[]=).with(:Groups, ['a-task-group'])
 
 
-              nomad_client.deployment.promote(deployment_id, false, ['a-task-group'])
+              nomad_client.deployment.promote(deployment_id, all: false, groups: ['a-task-group'])
             end
           end
         end

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -113,7 +113,7 @@ module NomadClient
               expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, ['an-allocation-id-to-set-to-healthy'])
               expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, nil)
 
-              nomad_client.deployment.allocation_health(deployment_id, { healthy_allocation_ids: ['an-allocation-id-to-set-to-healthy']})
+              nomad_client.deployment.allocation_health(deployment_id, healthy_allocation_ids: ['an-allocation-id-to-set-to-healthy'])
             end
           end
           context 'when setting allocations to unhealthy' do
@@ -125,7 +125,7 @@ module NomadClient
               expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, nil)
               expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, ['an-allocation-id-to-set-to-unhealthy'])
 
-              nomad_client.deployment.allocation_health(deployment_id, { unhealthy_allocation_ids: ['an-allocation-id-to-set-to-unhealthy']})
+              nomad_client.deployment.allocation_health(deployment_id, unhealthy_allocation_ids: ['an-allocation-id-to-set-to-unhealthy'])
             end
           end
         end

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+module NomadClient
+  module Api
+    RSpec.describe 'Deployment' do
+      let!(:nomad_client) { NomadClient::Connection.new('http://nomad.local') }
+
+      describe 'deployment' do
+        it 'should add the deployment method to the NomadClient::Connection class' do
+          expect(nomad_client).to respond_to :deployment
+          expect(nomad_client.deployment).to be_kind_of NomadClient::Api::Deployment
+        end
+      end
+
+      describe 'Deployment API methods' do
+        let(:block_receiver)   { double(:block_receiver) }
+        let(:deployment_id)    { 'deployment-id' }
+        let(:nomad_deployment) { { "ID" => deployment_id } }
+        let!(:connection)      { double(:connection) }
+
+        before do
+          allow(nomad_client).to receive(:connection).and_return(connection)
+        end
+
+        describe '#get' do
+          it 'should call get with deployment_id on the deployment_id endpoint' do
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("deployment/#{deployment_id}")
+
+            nomad_client.deployment.get(deployment_id)
+          end
+        end
+
+
+        describe '#allocations' do
+          it 'should call get with deployment_id on the deployment allocations endpoint' do
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("deployment/allocations/#{deployment_id}")
+
+            nomad_client.deployment.allocations(deployment_id)
+          end
+        end
+
+        describe '#fail' do
+          it 'should call post with deployment_id on the deployment_id fail endpoint' do
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("deployment/fail/#{deployment_id}")
+
+            nomad_client.deployment.fail(deployment_id)
+          end
+        end
+
+        describe '#pause' do
+          context 'when pausing' do
+            it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
+              pause_params = {}
+              expect(connection).to receive(:post).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
+              expect(block_receiver).to receive(:params).and_return(pause_params)
+              expect(pause_params).to receive(:[]=).with(:Pause, true)
+
+              nomad_client.deployment.pause(deployment_id, true)
+            end
+          end
+          context 'when unpausing' do
+            it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
+              pause_params = {}
+              expect(connection).to receive(:post).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
+              expect(block_receiver).to receive(:params).and_return(pause_params)
+              expect(pause_params).to receive(:[]=).with(:Pause, false)
+
+              nomad_client.deployment.pause(deployment_id, false)
+            end
+          end
+        end
+
+        describe '#promote' do
+          context 'when promoting all' do
+            it 'should call post with deployment_id and an All boolean set to true on the deployment_id promote endpoint' do
+              promote_params = {}
+              expect(connection).to receive(:post).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
+              allow(block_receiver).to receive(:params).and_return(promote_params)
+              expect(promote_params).to receive(:[]=).with(:All, true)
+              expect(promote_params).to receive(:[]=).with(:Groups, nil)
+
+              nomad_client.deployment.promote(deployment_id, true)
+            end
+          end
+          context 'when promoting a subset' do
+            it 'should call post with deployment_id and an All boolean set to false and a set of groups on the deployment_id pause endpoint' do
+              promote_params = {}
+              expect(connection).to receive(:post).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
+              allow(block_receiver).to receive(:params).and_return(promote_params)
+              expect(promote_params).to receive(:[]=).with(:All, false)
+              expect(promote_params).to receive(:[]=).with(:Groups, ['a-task-group'])
+
+
+              nomad_client.deployment.promote(deployment_id, false, ['a-task-group'])
+            end
+          end
+        end
+
+
+        describe '#allocation_health' do
+          context 'when setting allocations to healthy' do
+            it 'should call post with deployment_id and a set of unhealthy allocation ids on the deployment_id allocation-health endpoint' do
+              promote_params = {}
+              expect(connection).to receive(:post).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployment/allocation-health/#{deployment_id}")
+              allow(block_receiver).to receive(:params).and_return(promote_params)
+              expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, ['an-allocation-id-to-set-to-healthy'])
+              expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, nil)
+
+              nomad_client.deployment.allocation_health(deployment_id, { healthy_allocation_ids: ['an-allocation-id-to-set-to-healthy']})
+            end
+          end
+          context 'when setting allocations to unhealthy' do
+            it 'should call post with deployment_id and a set of healthy allocation ids on the deployment_id allocation-health endpoint' do
+              promote_params = {}
+              expect(connection).to receive(:post).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployment/allocation-health/#{deployment_id}")
+              allow(block_receiver).to receive(:params).and_return(promote_params)
+              expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, nil)
+              expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, ['an-allocation-id-to-set-to-unhealthy'])
+
+              nomad_client.deployment.allocation_health(deployment_id, { unhealthy_allocation_ids: ['an-allocation-id-to-set-to-unhealthy']})
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -50,27 +50,26 @@ module NomadClient
         end
 
         describe '#pause' do
-          context 'when pausing' do
-            it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
-              pause_params = {}
-              expect(connection).to receive(:post).and_yield(block_receiver)
-              expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
-              expect(block_receiver).to receive(:params).and_return(pause_params)
-              expect(pause_params).to receive(:[]=).with(:Pause, true)
+          it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
+            pause_params = {}
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
+            expect(block_receiver).to receive(:params).and_return(pause_params)
+            expect(pause_params).to receive(:[]=).with(:Pause, true)
 
-              nomad_client.deployment.pause(deployment_id, true)
-            end
+            nomad_client.deployment.pause(deployment_id)
           end
-          context 'when unpausing' do
-            it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
-              pause_params = {}
-              expect(connection).to receive(:post).and_yield(block_receiver)
-              expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
-              expect(block_receiver).to receive(:params).and_return(pause_params)
-              expect(pause_params).to receive(:[]=).with(:Pause, false)
+        end
 
-              nomad_client.deployment.pause(deployment_id, false)
-            end
+        describe '#unpause' do
+          it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
+            pause_params = {}
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
+            expect(block_receiver).to receive(:params).and_return(pause_params)
+            expect(pause_params).to receive(:[]=).with(:Pause, false)
+
+            nomad_client.deployment.unpause(deployment_id)
           end
         end
 

--- a/spec/nomad_client/api/deployments_spec.rb
+++ b/spec/nomad_client/api/deployments_spec.rb
@@ -22,11 +22,27 @@ module NomadClient
         end
 
         describe '#get' do
-          it 'should call get with deployments endpoint' do
-            expect(connection).to receive(:get).and_yield(block_receiver)
-            expect(block_receiver).to receive(:url).with("deployments")
+          context 'with no prefix' do
+            it 'should call get on the deployments endpoint with a nil prefix' do
+              prefix_params = {}
+              expect(connection).to receive(:get).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployments")
+              allow(block_receiver).to receive(:params).and_return(prefix_params)
+              expect(prefix_params).to receive(:[]=).with(:prefix, nil)
 
-            nomad_client.deployments.get
+              nomad_client.deployments.get
+            end
+          end
+          context 'with a prefix' do
+            it 'should call get on the deployments endpoint with a prefix supplied' do
+              prefix_params = {}
+              expect(connection).to receive(:get).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with("deployments")
+              allow(block_receiver).to receive(:params).and_return(prefix_params)
+              expect(prefix_params).to receive(:[]=).with(:prefix, 'my-cool')
+
+              nomad_client.deployments.get('my-cool')
+            end
           end
         end
       end

--- a/spec/nomad_client/api/deployments_spec.rb
+++ b/spec/nomad_client/api/deployments_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+module NomadClient
+  module Api
+    RSpec.describe 'Deployments' do
+      let!(:nomad_client) { NomadClient::Connection.new('http://nomad.local') }
+
+      describe 'deployments' do
+        it 'should add the deployments method to the NomadClient::Connection class' do
+          expect(nomad_client).to respond_to :deployments
+          expect(nomad_client.deployments).to be_kind_of NomadClient::Api::Deployments
+        end
+      end
+
+      describe 'Deployments API methods' do
+        let(:block_receiver)   { double(:block_receiver) }
+        let(:deployment_id)    { 'deployment-job' }
+        let(:nomad_deployment) { { "ID" => deployment_id } }
+        let!(:connection)      { double(:connection) }
+
+        before do
+          allow(nomad_client).to receive(:connection).and_return(connection)
+        end
+
+        describe '#get' do
+          it 'should call get with deployments endpoint' do
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("deployments")
+
+            nomad_client.deployments.get
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/nomad_client/api/deployments_spec.rb
+++ b/spec/nomad_client/api/deployments_spec.rb
@@ -41,7 +41,7 @@ module NomadClient
               allow(block_receiver).to receive(:params).and_return(prefix_params)
               expect(prefix_params).to receive(:[]=).with(:prefix, 'my-cool')
 
-              nomad_client.deployments.get('my-cool')
+              nomad_client.deployments.get(prefix: 'my-cool')
             end
           end
         end

--- a/spec/nomad_client/api/deployments_spec.rb
+++ b/spec/nomad_client/api/deployments_spec.rb
@@ -22,12 +22,12 @@ module NomadClient
         end
 
         describe '#get' do
+          let(:prefix_params) { {} }
+          let(:block_receiver) { double(:block_receiver, params: prefix_params) }
           context 'with no prefix' do
             it 'should call get on the deployments endpoint with a nil prefix' do
-              prefix_params = {}
               expect(connection).to receive(:get).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployments")
-              allow(block_receiver).to receive(:params).and_return(prefix_params)
               expect(prefix_params).to receive(:[]=).with(:prefix, nil)
 
               nomad_client.deployments.get
@@ -35,10 +35,8 @@ module NomadClient
           end
           context 'with a prefix' do
             it 'should call get on the deployments endpoint with a prefix supplied' do
-              prefix_params = {}
               expect(connection).to receive(:get).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployments")
-              allow(block_receiver).to receive(:params).and_return(prefix_params)
               expect(prefix_params).to receive(:[]=).with(:prefix, 'my-cool')
 
               nomad_client.deployments.get(prefix: 'my-cool')

--- a/spec/nomad_client/api/node_spec.rb
+++ b/spec/nomad_client/api/node_spec.rb
@@ -56,7 +56,7 @@ module NomadClient
               expect(block_receiver).to receive(:url).with("node/#{node_id}/drain")
               expect(block_receiver).to receive(:params).and_return(params_hash)
               expect(params_hash).to receive_message_chain(:[]=).with(:enable, false)
-              nomad_client.node.drain(node_id, false)
+              nomad_client.node.drain(node_id, enable: false)
             end
           end
         end


### PR DESCRIPTION
This PR adds support for the `deployments` endpoint, which was newly added in Nomad.

For more information about the endpoint see: 
https://www.nomadproject.io/api/deployments.html

For information on the potential usages of the endpoint:
https://www.nomadproject.io/docs/operating-a-job/update-strategies/blue-green-and-canary-deployments.html