### PR TITLE
Update all endpoints which require body instead of query params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.4.1-node-browsers
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for nomad_client.
 
+## 0.3.1
+
+* Fixes bugs in non-GET endpoints which require body to be used instead of query params
+
 ## 0.3.0
 
 * Adds remaining endpoints according to the API documentation at https://www.nomadproject.io/api/index.html

--- a/lib/nomad_client/api/agent.rb
+++ b/lib/nomad_client/api/agent.rb
@@ -27,7 +27,9 @@ module NomadClient
       def join(addresses)
         connection.post do |req|
           req.url "agent/join"
-          req.params[:address] = addresses
+          req.body = {
+            "address" => addresses
+          }
         end
       end
 
@@ -51,7 +53,9 @@ module NomadClient
       def force_leave(node)
         connection.post do |req|
           req.url "agent/force-leave"
-          req.params[:node] = node
+          req.body = {
+            "node" => node
+          }
         end
       end
 
@@ -75,7 +79,9 @@ module NomadClient
       def update_servers(addresses)
         connection.post do |req|
           req.url "agent/servers"
-          req.params[:address] = addresses
+          req.body = {
+            "address" => addresses
+          }
         end
       end
 

--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -53,7 +53,9 @@ module NomadClient
       def pause(id)
         connection.post do |req|
           req.url "deployment/pause/#{id}"
-          req.params[:Pause] = true
+          req.body = {
+            "Pause" => true
+          }
         end
       end
 
@@ -66,7 +68,9 @@ module NomadClient
       def unpause(id)
         connection.post do |req|
           req.url "deployment/pause/#{id}"
-          req.params[:Pause] = false
+          req.body = {
+            "Pause" => false
+          }
         end
       end
       alias_method :resume, :unpause
@@ -82,8 +86,10 @@ module NomadClient
       def promote(id, all: false, groups: nil)
         connection.post do |req|
           req.url "deployment/promote/#{id}"
-          req.params[:All] = all
-          req.params[:Groups] = groups
+          req.body = {
+            "All" => all,
+            "Groups" => groups
+          }
         end
       end
 
@@ -100,8 +106,10 @@ module NomadClient
       def allocation_health(id, healthy_allocation_ids: nil, unhealthy_allocation_ids: nil)
         connection.post do |req|
           req.url "deployment/allocation-health/#{id}"
-          req.params[:HealthyAllocationIDs]   = healthy_allocation_ids
-          req.params[:UnhealthyAllocationIDs] = unhealthy_allocation_ids
+          req.body = {
+            "HealthyAllocationIDs" => healthy_allocation_ids,
+            "UnhealthyAllocationIDs" => unhealthy_allocation_ids
+          }
         end
       end
     end

--- a/lib/nomad_client/api/job.rb
+++ b/lib/nomad_client/api/job.rb
@@ -181,8 +181,10 @@ module NomadClient
       def dispatch(id, payload: '', meta: nil)
         connection.post do |req|
           req.url "job/#{id}/dispatch"
-          req.params[:Payload] = payload
-          req.params[:Meta]    = meta
+          req.body = {
+            "Payload" => payload,
+            "Meta" => meta
+          }
         end
       end
 
@@ -198,8 +200,10 @@ module NomadClient
       def revert(id, job_version: 0, enforce_prior_version: nil)
         connection.post do |req|
           req.url "job/#{id}/revert"
-          req.params[:JobVersion]          = job_version
-          req.params[:EnforcePriorVersion] = enforce_prior_version
+          req.body = {
+            "JobVersion" => job_version,
+            "EnforcePriorVersion" => enforce_prior_version
+          }
         end
       end
 
@@ -214,8 +218,10 @@ module NomadClient
       def stable(id, job_version: 0, stable: false)
         connection.post do |req|
           req.url "job/#{id}/stable"
-          req.params[:JobVersion] = job_version
-          req.params[:Stable]     = stable
+          req.body = {
+            "JobVersion" => job_version,
+            "Stable" => stable
+          }
         end
       end
 

--- a/lib/nomad_client/api/node.rb
+++ b/lib/nomad_client/api/node.rb
@@ -42,7 +42,9 @@ module NomadClient
       def drain(id, enable: true)
         connection.post do |req|
           req.url "node/#{id}/drain"
-          req.params[:enable] = enable
+          req.body = {
+            "enable" => enable
+          }
         end
       end
 

--- a/lib/nomad_client/api/operator.rb
+++ b/lib/nomad_client/api/operator.rb
@@ -30,8 +30,10 @@ module NomadClient
       def remove_raft_peer(address, stale: false)
         connection.delete do |req|
           req.url "operator/raft/peer"
-          req.params[:address] = address
-          req.params[:stale]   = stale
+          req.body = {
+            "address" => address,
+            "stale" => stale
+          }
         end
       end
     end

--- a/lib/nomad_client/api/search.rb
+++ b/lib/nomad_client/api/search.rb
@@ -18,8 +18,10 @@ module NomadClient
       def get(prefix, context)
         connection.post do |req|
           req.url "search"
-          req.params[:Prefix]  = prefix
-          req.params[:Context] = context
+          req.body = {
+            "Prefix" => prefix,
+            "Context" => context
+          }
         end
       end
     end

--- a/lib/nomad_client/version.rb
+++ b/lib/nomad_client/version.rb
@@ -1,3 +1,3 @@
 module NomadClient
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/nomad_client/api/agent_spec.rb
+++ b/spec/nomad_client/api/agent_spec.rb
@@ -30,12 +30,10 @@ module NomadClient
 
         describe '#join' do
           it 'should call post on the join endpoint with one or more addresses' do
-            params_hash = {}
             addresses = ['http://nomad.2.local', 'http://nomad.3.local']
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("agent/join")
-            expect(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:address, addresses)
+            expect(block_receiver).to receive(:body=).with({"address" => addresses})
             nomad_client.agent.join(addresses)
           end
         end
@@ -51,12 +49,10 @@ module NomadClient
 
         describe '#force_leave' do
           it 'should call post with a node name on the force-leave endpoint' do
-            params_hash = {}
             node = 'integration-3'
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("agent/force-leave")
-            expect(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:node, node)
+            expect(block_receiver).to receive(:body=).with({"node" => node})
             nomad_client.agent.force_leave(node)
           end
         end
@@ -73,12 +69,10 @@ module NomadClient
 
         describe '#update_servers' do
           it 'should call post on the servers endpoint with one or more addresses' do
-            params_hash = {}
             addresses = ['http://nomad.2.local:4646', 'http://nomad.3.local:4646']
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("agent/servers")
-            expect(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:address, addresses)
+            expect(block_receiver).to receive(:body=).with({"address" => addresses})
             nomad_client.agent.update_servers(addresses)
           end
         end

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -51,11 +51,9 @@ module NomadClient
 
         describe '#pause' do
           it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
-            pause_params = {}
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
-            expect(block_receiver).to receive(:params).and_return(pause_params)
-            expect(pause_params).to receive(:[]=).with(:Pause, true)
+            expect(block_receiver).to receive(:body=).with({"Pause" => true})
 
             nomad_client.deployment.pause(deployment_id)
           end
@@ -63,11 +61,9 @@ module NomadClient
 
         describe '#unpause' do
           it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
-            pause_params = {}
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
-            expect(block_receiver).to receive(:params).and_return(pause_params)
-            expect(pause_params).to receive(:[]=).with(:Pause, false)
+            expect(block_receiver).to receive(:body=).with({"Pause" => false})
 
             nomad_client.deployment.unpause(deployment_id)
           end
@@ -76,25 +72,18 @@ module NomadClient
         describe '#promote' do
           context 'when promoting all' do
             it 'should call post with deployment_id and an All boolean set to true on the deployment_id promote endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:All, true)
-              expect(promote_params).to receive(:[]=).with(:Groups, nil)
+              expect(block_receiver).to receive(:body=).with({"All" => true, "Groups" => nil})
 
               nomad_client.deployment.promote(deployment_id, all: true)
             end
           end
           context 'when promoting a subset' do
             it 'should call post with deployment_id and an All boolean set to false and a set of groups on the deployment_id pause endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:All, false)
-              expect(promote_params).to receive(:[]=).with(:Groups, ['a-task-group'])
-
+              expect(block_receiver).to receive(:body=).with({"All" => false, "Groups" => ['a-task-group']})
 
               nomad_client.deployment.promote(deployment_id, all: false, groups: ['a-task-group'])
             end
@@ -105,24 +94,18 @@ module NomadClient
         describe '#allocation_health' do
           context 'when setting allocations to healthy' do
             it 'should call post with deployment_id and a set of unhealthy allocation ids on the deployment_id allocation-health endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/allocation-health/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, ['an-allocation-id-to-set-to-healthy'])
-              expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, nil)
+              expect(block_receiver).to receive(:body=).with({"HealthyAllocationIDs" => ['an-allocation-id-to-set-to-healthy'], "UnhealthyAllocationIDs" => nil})
 
               nomad_client.deployment.allocation_health(deployment_id, healthy_allocation_ids: ['an-allocation-id-to-set-to-healthy'])
             end
           end
           context 'when setting allocations to unhealthy' do
             it 'should call post with deployment_id and a set of healthy allocation ids on the deployment_id allocation-health endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/allocation-health/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, nil)
-              expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, ['an-allocation-id-to-set-to-unhealthy'])
+              expect(block_receiver).to receive(:body=).with({"HealthyAllocationIDs" => nil, "UnhealthyAllocationIDs" => ['an-allocation-id-to-set-to-unhealthy']})
 
               nomad_client.deployment.allocation_health(deployment_id, unhealthy_allocation_ids: ['an-allocation-id-to-set-to-unhealthy'])
             end

--- a/spec/nomad_client/api/job_spec.rb
+++ b/spec/nomad_client/api/job_spec.rb
@@ -158,13 +158,10 @@ module NomadClient
           it 'should call post on the dispatch endpoint with the job_id, payload, and meta hash' do
             payload         = ::Base64.encode64('some-payload')
             meta            = { 'key' => 'value' }
-            dispatch_params = {}
 
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("job/#{job_id}/dispatch")
-            allow(block_receiver).to receive(:params).and_return(dispatch_params)
-            expect(dispatch_params).to receive(:[]=).with(:Payload, payload)
-            expect(dispatch_params).to receive(:[]=).with(:Meta, meta)
+            expect(block_receiver).to receive(:body=).with({"Payload" => payload, "Meta" => meta})
 
             nomad_client.job.dispatch(job_id, payload: payload, meta: meta)
           end
@@ -174,13 +171,10 @@ module NomadClient
           it 'should call post on the revert endpoint with the job_id, job_version, and an enforce_prior_version param' do
             job_version           = 1
             enforce_prior_version = true
-            revert_params         = {}
 
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("job/#{job_id}/revert")
-            allow(block_receiver).to receive(:params).and_return(revert_params)
-            expect(revert_params).to receive(:[]=).with(:JobVersion, job_version)
-            expect(revert_params).to receive(:[]=).with(:EnforcePriorVersion, enforce_prior_version)
+            expect(block_receiver).to receive(:body=).with({"JobVersion" => job_version, "EnforcePriorVersion" => enforce_prior_version})
 
             nomad_client.job.revert(job_id, job_version: job_version, enforce_prior_version: enforce_prior_version)
           end
@@ -190,13 +184,10 @@ module NomadClient
           it 'should call post on the stable endpoint with the job_id, job_version, and a stable param' do
             job_version   = 2
             stable        = false
-            stable_params = {}
 
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("job/#{job_id}/stable")
-            allow(block_receiver).to receive(:params).and_return(stable_params)
-            expect(stable_params).to receive(:[]=).with(:JobVersion, job_version)
-            expect(stable_params).to receive(:[]=).with(:Stable, stable)
+            expect(block_receiver).to receive(:body=).with({"JobVersion" => job_version, "Stable" => stable})
 
             nomad_client.job.stable(job_id, job_version: job_version, stable: stable)
           end

--- a/spec/nomad_client/api/node_spec.rb
+++ b/spec/nomad_client/api/node_spec.rb
@@ -41,21 +41,17 @@ module NomadClient
         describe '#drain' do
           context 'without supplying enable' do
             it 'should call post with a node_id and an enable flag set to true' do
-              params_hash = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("node/#{node_id}/drain")
-              expect(block_receiver).to receive(:params).and_return(params_hash)
-              expect(params_hash).to receive_message_chain(:[]=).with(:enable, true)
+              expect(block_receiver).to receive_message_chain(:body=).with({"enable" => true})
               nomad_client.node.drain(node_id)
             end
           end
           context 'when supplying enable' do
             it 'should call post with a node_id and an enable flag set to false' do
-              params_hash = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("node/#{node_id}/drain")
-              expect(block_receiver).to receive(:params).and_return(params_hash)
-              expect(params_hash).to receive_message_chain(:[]=).with(:enable, false)
+              expect(block_receiver).to receive_message_chain(:body=).with({"enable" => false})
               nomad_client.node.drain(node_id, enable: false)
             end
           end

--- a/spec/nomad_client/api/operator_spec.rb
+++ b/spec/nomad_client/api/operator_spec.rb
@@ -35,13 +35,10 @@ module NomadClient
           it 'should call delete on the peer endpoint with an address and stale param' do
             stale = true
             address = 'https://nomad.local'
-            params_hash = {}
 
             expect(connection).to receive(:delete).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("operator/raft/peer")
-            allow(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:address, address)
-            expect(params_hash).to receive_message_chain(:[]=).with(:stale, stale)
+            expect(block_receiver).to receive_message_chain(:body=).with({"address" => address, "stale" => stale})
             nomad_client.operator.remove_raft_peer(address, stale: stale)
           end
         end

--- a/spec/nomad_client/api/search_spec.rb
+++ b/spec/nomad_client/api/search_spec.rb
@@ -27,8 +27,10 @@ module NomadClient
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("search")
             allow(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:Prefix, prefix)
-            expect(params_hash).to receive_message_chain(:[]=).with(:Context, context_param)
+            expect(block_receiver).to receive(:body=).with({
+              "Prefix" => prefix,
+              "Context" => context_param
+            })
             nomad_client.search.get(prefix, context_param)
           end
         end


### PR DESCRIPTION
Nomad POST requests should use body instead of query params.

This PR changes any query params on non-get calls to use the body instead.